### PR TITLE
fix: Fix AttributeError on logging statements

### DIFF
--- a/cinq_auditor_required_tags/__init__.py
+++ b/cinq_auditor_required_tags/__init__.py
@@ -218,7 +218,7 @@ class RequiredTagsAuditor(BaseAuditor):
 
                     instance.stop()
                     self.log.debug('Shutdown instance {}/{}'.format(
-                        issue.account.account_name,
+                        issue.instance.account.account_name,
                         issue.instance_id
                     ))
 
@@ -261,7 +261,7 @@ class RequiredTagsAuditor(BaseAuditor):
 
                     terminated_instances.setdefault(issue.instance.account, []).append(issue.instance.id)
                     self.log.debug('Terminated instance {}/{}'.format(
-                        issue.account.account_name,
+                        issue.instance.account.account_name,
                         issue.instance_id
                     ))
 


### PR DESCRIPTION
Fix an issue where the log messages generated raised an exception due to an AttributeError, which in term causes instances to not correctly progress from shutdown to termination.