### PR TITLE
Fix grace period comparison

### DIFF
--- a/cinq_auditor_required_tags/__init__.py
+++ b/cinq_auditor_required_tags/__init__.py
@@ -165,7 +165,7 @@ class RequiredTagsAuditor(BaseAuditor):
 
         new_issues = {
             resource_id: resource for resource_id, resource in known_resources.items()
-                if ((datetime.now() - resource['resource'].launch_date).seconds//3600) >= self.grace_period
+                if ((datetime.now() - resource['resource'].launch_date).total_seconds() // 3600) >= self.grace_period
         }
 
         db.session.commit()


### PR DESCRIPTION
The correct way to get total number of seconds contained in the timedelta should be `.total_seconds()`.
`.seconds` will only contain the second portion and will cause false negative